### PR TITLE
Add setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # home-assistant-nzb-clients
-Provide NZB client support for integration with home-assistant
+### Python implementation of SABnzbd API.
+
+This is for use with home-assistant but can also be used stand-alone.

--- a/pysabnzbd/__init__.py
+++ b/pysabnzbd/__init__.py
@@ -1,7 +1,6 @@
 __author__ = 'jamespcole'
 
 import requests
-import json
 from requests.exceptions import RequestException
 
 class SabnzbdApi(object):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='python-sabnzbd',
+      version='0.1',
+      description='Python API for talking to SABnzbd',
+      url='https://github.com/jamespcole/home-assistant-nzb-clients',
+      author='James Cole',
+      license='GPLv2',
+      install_requires=['requests>=2.0'],
+      packages=['pysabnzbd'],
+      zip_safe=True)


### PR DESCRIPTION
Adding `setup.py` will allow people to install your repository by referring to it from  `requirements.txt`. And that is exactly what I am planning to do for Home Assistant.

:dancers: 

Another thing, slightly related. Since this repository can be used standalone, would it be an idea to rename it to `python-sabnzbd`? That way it might attract other developers.
